### PR TITLE
Fix repeated perm call function reference

### DIFF
--- a/R/limma_diff_interaction.R
+++ b/R/limma_diff_interaction.R
@@ -2,7 +2,7 @@
 #'
 #' Computes gene-wise interaction statistics using limma for the difference in group effects
 #' between ancestries (ancestry X minus ancestry Y), matching the logic of
-#' \code{perm_diff_interaction}.
+#' \code{perm_interaction}.
 #'
 #' @param X Expression matrix for ancestry X. Rows = samples, columns = genes.
 #' @param Y Expression matrix for ancestry Y. Rows = samples, columns = genes.

--- a/R/repeated_perm_diff_interaction.R
+++ b/R/repeated_perm_diff_interaction.R
@@ -1,7 +1,7 @@
 #' Repeated Permutation Interaction Test on Stratified Subsets
 #'
 #' Performs multiple stratified subsamples of the overrepresented group,
-#' runs `perm_diff_interaction()` on each, and aggregates the results.
+#' runs `perm_interaction()` on each, and aggregates the results.
 #'
 #' @param X Expression matrix (samples × genes) for the overrepresented ancestry.
 #' @param Y Expression matrix for the underrepresented ancestry.
@@ -12,7 +12,7 @@
 #' @param a_col Name of the ancestry variable.
 #' @param features Optional vector of feature names to include (default: all).
 #' @param n_iter Number of stratified subsample iterations.
-#' @param B Number of permutations in each `perm_diff_interaction()` call.
+#' @param B Number of permutations in each `perm_interaction()` call.
 #' @param seed Base random seed for reproducibility.
 #'
 #' @return A list with:
@@ -50,7 +50,7 @@ repeated_perm_diff_interaction <- function(
 
     if (nrow(split$test$X) == 0) next
 
-    result <- perm_diff_interaction(
+    result <- perm_interaction(
       X = split$test$X,
       Y = split$inference$X,
       MX = split$test$M,

--- a/man/plot_T_distribution.Rd
+++ b/man/plot_T_distribution.Rd
@@ -13,7 +13,7 @@ plot_T_distribution(
 )
 }
 \arguments{
-\item{x}{A named list output from \code{perm_diff_interaction()} or similar, containing null distributions
+\item{x}{A named list output from \code{perm_interaction()} or similar, containing null distributions
 and summary statistics. Must include a \code{summary_stats} data frame and either \code{T_perm} or
 \code{T_boot} depending on the statistic type.}
 

--- a/man/repeated_perm_diff_interaction.Rd
+++ b/man/repeated_perm_diff_interaction.Rd
@@ -37,7 +37,7 @@ repeated_perm_diff_interaction(
 
 \item{n_iter}{Number of stratified subsample iterations.}
 
-\item{B}{Number of permutations in each `perm_diff_interaction()` call.}
+\item{B}{Number of permutations in each `perm_interaction()` call.}
 
 \item{seed}{Base random seed for reproducibility.}
 }
@@ -51,5 +51,5 @@ A list with:
 }
 \description{
 Performs multiple stratified subsamples of the overrepresented group,
-runs `perm_diff_interaction()` on each, and aggregates the results.
+runs `perm_interaction()` on each, and aggregates the results.
 }

--- a/vignettes/single_subset_run.Rmd
+++ b/vignettes/single_subset_run.Rmd
@@ -93,7 +93,7 @@ str(split)
 
 # Permutation interaction analysis
 Next, we use the `test` and `inference` sets to evaluate interaction effects between condition and ancestry using permutation-based inference.
-The `perm_diff_interaction()` function estimates differential interactions between groups using both bootstrapping and permtuation.
+The `perm_interaction()` function estimates differential interactions between groups using both bootstrapping and permutation.
 ```{r interaction_analysis, fig.alt = "Bar plot showing interaction results"}
 # Define the ancestry column and the condition column
 g_col <- "condition"


### PR DESCRIPTION
## Summary
- fix call to `perm_interaction` inside `repeated_perm_diff_interaction`
- update documentation and vignette references accordingly

## Testing
- `devtools::test()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fec40348c8326818f9ceab7d89c6d