### PR TITLE
Fix roxygen docs to match function signatures

### DIFF
--- a/R/ggsaveDK.R
+++ b/R/ggsaveDK.R
@@ -1,7 +1,7 @@
 #' Save ggplot with optional legend removal and sensible defaults
 #'
+#' @param filename File path to save the plot.
 #' @param plot A ggplot object.
-#' @param filename File path to save to.
 #' @param legend Logical. If FALSE, removes the legend before saving.
 #' @param width Width in inches. Default is 7.
 #' @param height Height in inches. Default is 7.

--- a/R/perm_interaction_effect.R
+++ b/R/perm_interaction_effect.R
@@ -1,17 +1,16 @@
-#' Simple Permutation-Based Interaction Test (No Bootstrapping, No Convergence)
+#' Simple permutation interaction test without bootstrapping
 #'
-#' Tests if condition effects (g1 vs g2) are different between ancestries using permutation.
+#' Tests if condition effects differ between ancestries using permutation.
 #'
 #' @param X Expression matrix for ancestry A (samples x genes)
 #' @param Y Expression matrix for ancestry B (samples x genes)
 #' @param MX Metadata for X (must include group and ancestry columns)
 #' @param MY Metadata for Y
-#' @param g_col Column in metadata for condition/group (factor with 2 levels)
+#' @param g_col Metadata column for group (factor with two levels)
 #' @param B Number of permutations
 #' @param seed Optional seed for reproducibility
-#' @param permute Logical. Whether to perform permutation test
 #'
-#' @return A list with summary stats, permutation matrix, and number of valid permutations
+#' @return Summary stats, null matrix, and valid permutation count.
 #' @export
 perm_interaction_effect <- function(
   X,          

--- a/R/plot_correlation_difference.R
+++ b/R/plot_correlation_difference.R
@@ -11,6 +11,7 @@
 #' @param x_label Label for the x-axis (default is NULL).
 #' @param y_label Label for the y-axis (default is NULL).
 #' @param title Optional plot title.
+#' @param point_size Point size for annotations.
 #'
 #' @return A ggplot2 object showing the correlation comparison.
 #' 

--- a/R/plot_feature.R
+++ b/R/plot_feature.R
@@ -1,17 +1,18 @@
 #' Plot feature distributions across two splits
 #'
 #' Generates boxplots of scaled feature values across two data splits
-#' (X and Y), stratified by a grouping column, optionally for specified features.
+#' (X and Y) stratified by a grouping column.
 #'
-#' @param X A numeric matrix or data frame for the test split
-#' @param Y A numeric matrix or data frame for the inference split
-#' @param MX Metadata for X, containing IDs and group information
-#' @param MY Metadata for Y, containing IDs and group information
-#' @param features Character vector of feature names to plot.
-#'   Defaults to first 9 common features if NULL.
-#' @param g_col Column name in metadata indicating the grouping (e.g., condition)
-#' @param id_col Column name in metadata for sample identifiers (assumes rownames of matrix are IDs)
-#' @param title Optional title for the plot
+#' @param X Numeric matrix or data frame for the test split.
+#' @param Y Numeric matrix or data frame for the inference split.
+#' @param MX Metadata for X with IDs and group information.
+#' @param MY Metadata for Y with IDs and group information.
+#' @param g_col Metadata column indicating the grouping.
+#' @param features Features to plot. If NULL, first nine common features
+#'   are used.
+#' @param title Optional plot title.
+#' @param x_label Label for the x-axis.
+#' @param y_label Label for the y-axis.
 #'
 #' @return A ggplot2 object containing the faceted boxplot
 #' @export

--- a/R/plot_feature_demographics.R
+++ b/R/plot_feature_demographics.R
@@ -2,6 +2,8 @@
 #'
 #' @param summary_list The `summary` list from `sim_imbalanced_groups`.
 #' @param title Optional plot title.
+#' @param x_label Label for the x-axis.
+#' @param y_label Label for the y-axis.
 #'
 #' @return A ggplot object.
 #' @export

--- a/R/plot_stratified_feature.R
+++ b/R/plot_stratified_feature.R
@@ -4,19 +4,19 @@
 #' (X, Y, R) stratified by a grouping column, optionally for
 #' specified features.
 #'
-#' @param X A numeric matrix or data frame for the test split
-#' @param Y A numeric matrix or data frame for the inference split
-#' @param R A numeric matrix or data frame for the train split
-#' @param MX Metadata for X, containing IDs and group information
-#' @param MY Metadata for Y, containing IDs and group information
-#' @param MR Metadata for R, containing IDs and group information
-#' @param features Character vector of feature names to plot.
-#'   Defaults to first 9 common features if NULL.
-#' @param g_col Column name in metadata indicating the grouping
-#'   (e.g., condition)
-#' @param id_col Column name in metadata for sample identifiers (assumes rownames of matrix are ids)
-#' @param title Optional title for the plot
-#' @param point_size Numeric value controlling point/label size (currently not used in plotting directly).
+#' @param X Numeric matrix or data frame for the test split.
+#' @param Y Numeric matrix or data frame for the inference split.
+#' @param R Numeric matrix or data frame for the train split.
+#' @param MX Metadata for X with IDs and group information.
+#' @param MY Metadata for Y with IDs and group information.
+#' @param MR Metadata for R with IDs and group information.
+#' @param fill_var Metadata column used for fill grouping.
+#' @param features Features to plot; uses first nine common ones if NULL.
+#' @param id_col Column with sample identifiers. Uses rownames when NULL.
+#' @param title Optional plot title.
+#' @param x_label Label for the x-axis.
+#' @param y_label Label for the y-axis.
+#' @param point_size Numeric value controlling point size.
 #'
 #' @return A ggplot2 object containing the faceted boxplot
 #' @export


### PR DESCRIPTION
## Summary
- update documentation for `ggsaveDK`
- update documentation for `perm_interaction_effect`
- update documentation for feature plotting helpers
- document missing `point_size` parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e4062e8dc83268bb274b79878278f